### PR TITLE
Added "newline" support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,15 @@
     "npm-asset/highlight.js": "^9.18",
     "npm-asset/katex": "^0.11",
     "npm-asset/quill": "^1.3",
+    "npm-asset/quill-smart-break": ">= 0.1.1",
     "phpunit/phpunit": "^7.5",
     "roave/security-advisories": "dev-master"
   },
   "suggest": {
     "npm-asset/highlight.js": "For local highlight.js assets",
     "npm-asset/katex": "For local KaTeX assets",
-    "npm-asset/quill": "For local Quill assets"
+    "npm-asset/quill": "For local Quill assets",
+    "npm-asset/quill-smart-break": "For 'SHIFT + Enter' newline support"
   },
   "autoload": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "npm-asset/highlight.js": "^9.18",
     "npm-asset/katex": "^0.11",
     "npm-asset/quill": "^1.3",
-    "npm-asset/quill-smart-break": ">= 0.1.1",
+    "npm-asset/quill-smart-break": ">= 0.1.1 <1.0.0",
     "phpunit/phpunit": "^7.5",
     "roave/security-advisories": "dev-master"
   },

--- a/src/Quill.php
+++ b/src/Quill.php
@@ -574,10 +574,6 @@ class Quill extends InputWidget
             }
         }
 
-        if ($this->isSmartBreak() && $this->localAssets) {
-            SmartBreakLocalAsset::register($view);
-        }
-
         if ($this->localAssets) {
             $asset = QuillLocalAsset::register($view);
         } else {
@@ -585,6 +581,10 @@ class Quill extends InputWidget
             $asset->version = $this->quillVersion;
         }
         $asset->theme = $this->theme;
+
+        if ($this->isSmartBreak() && $this->localAssets) {
+            SmartBreakLocalAsset::register($view);
+        }
 
         $configs = Json::encode($this->getConfig());
         $editor = 'q_' . Inflector::slug($this->id, '_');

--- a/src/Quill.php
+++ b/src/Quill.php
@@ -10,6 +10,7 @@ use bizley\quill\assets\KatexAsset;
 use bizley\quill\assets\KatexLocalAsset;
 use bizley\quill\assets\QuillAsset;
 use bizley\quill\assets\QuillLocalAsset;
+use bizley\quill\assets\SmartBreakLocalAsset;
 use yii\base\InvalidConfigException;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Html;
@@ -156,6 +157,13 @@ class Quill extends InputWidget
     public $configuration;
 
     /**
+     * @var boolean Set true to enable smart line breaks in quill (SHIFT + Enter new lines).
+     * The `npm-asset/quill-smart-break` package is needed to make this work.
+     * @since 3.1.0
+     */
+    public $smartBreak = false;
+
+    /**
      * @var string KaTeX version to fetch from https://cdn.jsdelivr.net
      * Used when Formula module is added.
      * This property is skipped if $localAssets is set to true (KaTeX version is as set by composer then).
@@ -295,6 +303,10 @@ class Quill extends InputWidget
         if ($name === 'syntax') {
             $this->setHighlightJs(true);
         }
+
+        if ($name === 'smart-breaker') {
+            $this->setSmartBreak(true);
+        }
     }
 
     /**
@@ -305,6 +317,29 @@ class Quill extends InputWidget
     public function setConfig(array $config): void
     {
         $this->_quillConfiguration = $config;
+    }
+
+    /** @var bool */
+    private $_smartBreak = false;
+
+    /**
+     * Checks whether the Smart break needs to be added.
+     * @return bool
+     * @since 3.1.0
+     */
+    public function isSmartBreak(): bool
+    {
+        return $this->_smartBreak;
+    }
+
+    /**
+     * Sets Smart break flag.
+     * @param bool $smartBreak
+     * @since 3.1.0
+     */
+    public function setSmartBreak(bool $smartBreak): void
+    {
+        $this->_smartBreak = $smartBreak;
     }
 
     /** @var bool */
@@ -391,8 +426,12 @@ class Quill extends InputWidget
                 $this->addConfig('formats', $this->formats);
             }
 
-            if ($this->readOnly !== null && (bool) $this->readOnly) {
+            if ($this->readOnly !== null && (bool)$this->readOnly) {
                 $this->addConfig('readOnly', true);
+            }
+
+            if ($this->smartBreak !== null && (bool)$this->smartBreak) {
+                $this->modules['smart-breaker'] = true;
             }
 
             if (!empty($this->modules)) {
@@ -533,6 +572,10 @@ class Quill extends InputWidget
                 $highlightAsset->version = $this->highlightVersion;
                 $highlightAsset->style = $this->highlightStyle;
             }
+        }
+
+        if ($this->isSmartBreak() && $this->localAssets) {
+            SmartBreakLocalAsset::register($view);
         }
 
         if ($this->localAssets) {

--- a/src/Quill.php
+++ b/src/Quill.php
@@ -557,7 +557,7 @@ class Quill extends InputWidget
                 $highlightAsset->style = $this->highlightStyle;
             }
 
-            QuillLocalAsset::register($view);
+            $asset = QuillLocalAsset::register($view);
 
             if ($this->isSmartBreak()) {
                 SmartBreakLocalAsset::register($view);
@@ -577,6 +577,7 @@ class Quill extends InputWidget
             $asset = QuillAsset::register($view);
             $asset->version = $this->quillVersion;
         }
+        $asset->theme = $this->theme;
 
         $configs = Json::encode($this->getConfig());
         $editor = 'q_' . Inflector::slug($this->id, '_');

--- a/src/assets/SmartBreakLocalAsset.php
+++ b/src/assets/SmartBreakLocalAsset.php
@@ -1,23 +1,23 @@
 <?php
-/**
- * @package yii2-quill
- * @author Simon Karlen <simi.albi@gmail.com>
- */
+
+declare(strict_types=1);
 
 namespace bizley\quill\assets;
 
-
 use yii\web\AssetBundle;
 
+/**
+ * Smart break assets.
+ *
+ * smart-breaker.js can be found at
+ * https://github.com/simialbi/quill-smart-break
+ * @author Simon Karlen <simi.albi@outlook.com>
+ */
 class SmartBreakLocalAsset extends AssetBundle
 {
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritdoc} */
     public $sourcePath = '@npm/quill-smart-break/dist';
 
-    /**
-     * {@inheritDoc}
-     */
+    /** {@inheritdoc} */
     public $js = ['smart-breaker.min.js'];
 }

--- a/src/assets/SmartBreakLocalAsset.php
+++ b/src/assets/SmartBreakLocalAsset.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * @package yii2-quill
+ * @author Simon Karlen <simi.albi@gmail.com>
+ */
+
+namespace bizley\quill\assets;
+
+
+use yii\web\AssetBundle;
+
+class SmartBreakLocalAsset extends AssetBundle
+{
+    /**
+     * {@inheritDoc}
+     */
+    public $sourcePath = '@npm/quill-smart-break/dist';
+
+    /**
+     * {@inheritDoc}
+     */
+    public $js = ['smart-breaker.min.js'];
+}

--- a/tests/QuillTest.php
+++ b/tests/QuillTest.php
@@ -10,6 +10,7 @@ use bizley\quill\assets\KatexAsset;
 use bizley\quill\assets\KatexLocalAsset;
 use bizley\quill\assets\QuillAsset;
 use bizley\quill\assets\QuillLocalAsset;
+use bizley\quill\assets\SmartBreakLocalAsset;
 use bizley\quill\Quill;
 use PHPUnit\Framework\TestCase;
 use Yii;
@@ -677,6 +678,46 @@ class QuillTest extends TestCase
      * @test
      * @throws InvalidConfigException
      */
+    public function shouldRegisterLocalQuillAndSmartBreak()
+    {
+        static::setApp();
+
+        $this->assertSame(
+            '<input type="hidden" id="quill-0" name="test"><div id="editor-quill-0" style="min-height:150px;"></div>',
+            (
+            new Quill(
+                [
+                    'name' => 'test',
+                    'localAssets' => true,
+                    'modules' => ['smart-breaker' => true]
+                ]
+            )
+            )->run()
+        );
+        $this->assertSame(
+            [
+                QuillLocalAsset::class,
+                SmartBreakLocalAsset::class
+            ],
+            array_keys(Yii::$app->view->assetBundles)
+        );
+        $this->assertSame(['smart-breaker.min.js'], Yii::$app->view->assetBundles[SmartBreakLocalAsset::class]->js);
+        $this->assertSame(
+            [
+                'var q_quill_0=new Quill("#editor-quill-0",'
+                . '{"theme":"snow","modules":{"smart-breaker":true,"toolbar":true}});'
+                . 'q_quill_0.on(\'text-change\',function(){'
+                . 'document.getElementById("quill-0").value=q_quill_0.root.innerHTML;});'
+            ],
+            array_values(Yii::$app->view->js[View::POS_END])
+        );
+        Yii::$app = null;
+    }
+
+    /**
+     * @test
+     * @throws InvalidConfigException
+     */
     public function shouldRegisterCDNQuillAndHighlightJs(): void
     {
         static::setApp();
@@ -842,6 +883,52 @@ class QuillTest extends TestCase
             [
                 'var q_quill_0=new Quill("#editor-quill-0",'
                 . '{"theme":"snow","modules":{"syntax":true,"formula":true,"toolbar":[["code-block","formula"]]}});'
+                . 'q_quill_0.on(\'text-change\',function(){'
+                . 'document.getElementById("quill-0").value=q_quill_0.root.innerHTML;});'
+            ],
+            array_values(Yii::$app->view->js[View::POS_END])
+        );
+        Yii::$app = null;
+    }
+
+    /**
+     * @test
+     * @throws InvalidConfigException
+     */
+    public function shouldRegisterLocalQuillKatexAndHighlightJsAndSmartBreak(): void
+    {
+        static::setApp();
+
+        $this->assertSame(
+            '<input type="hidden" id="quill-0" name="test"><div id="editor-quill-0" style="min-height:150px;"></div>',
+            (
+            new Quill(
+                [
+                    'name' => 'test',
+                    'localAssets' => true,
+                    'modules' => [
+                        'syntax' => true,
+                        'formula' => true,
+                        'smart-breaker' => true
+                    ],
+                    'toolbarOptions' => [['code-block', 'formula']],
+                ]
+            )
+            )->run()
+        );
+        $this->assertSame(
+            [
+                KatexLocalAsset::class,
+                HighlightLocalAsset::class,
+                QuillLocalAsset::class,
+                SmartBreakLocalAsset::class
+            ],
+            array_keys(Yii::$app->view->assetBundles)
+        );
+        $this->assertSame(
+            [
+                'var q_quill_0=new Quill("#editor-quill-0",'
+                . '{"theme":"snow","modules":{"syntax":true,"formula":true,"smart-breaker":true,"toolbar":[["code-block","formula"]]}});'
                 . 'q_quill_0.on(\'text-change\',function(){'
                 . 'document.getElementById("quill-0").value=q_quill_0.root.innerHTML;});'
             ],


### PR DESCRIPTION
I realized there is no newline in quill editor, so I searched for a module. As there wasn't one but a workaround (based on this thread: https://github.com/quilljs/quill/issues/252), I built my own and would like to add the support simply usable in yii2 asset.